### PR TITLE
Inherit org's pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,0 @@
-# Proposed Changes
-
-> (Describe the changes and rationale behind them)
-
-## Related Issues
-
-> ([Github link][autolink-references] to related issues or pull requests)
-
-[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


### PR DESCRIPTION
Seeing if the pull request template can also be inherited from from the `.github` repo in the organization so it can be centralized as well.