### PR TITLE
Fix log level, settings and example config

### DIFF
--- a/amridm2mqtt/config.yaml
+++ b/amridm2mqtt/config.yaml
@@ -18,6 +18,7 @@ options:
   watched_meters: []
   wh_multiplier: 1000
   readings_per_hour: 12
+  mqtt: {}
 schema:
   watched_meters:
     - int

--- a/amridm2mqtt/rootfs/amridm2mqtt/settings.py
+++ b/amridm2mqtt/rootfs/amridm2mqtt/settings.py
@@ -8,7 +8,7 @@ import logging
 # List may contain only one entry - [12345678]
 # or multiple entries - [12345678, 98765432, 12340123]
 power_meters = os.environ["WATCHED_METERS"].replace(",", " ").split(" ")
-WATCHED_METERS = [int(meter_id) for meter_id in power_meters]
+WATCHED_METERS = [int(meter_id) for meter_id in power_meters if meter_id]
 
 # multiplier to get reading to Watt Hours (Wh)
 # examples:
@@ -72,7 +72,7 @@ EV_TO_LOG_LEVEL = {
 LOG_LEVEL = EV_TO_LOG_LEVEL.get(os.environ.get("LOG_LEVEL"))
 
 # path to rtlamr
-RTLAMR = "/root/go/bin/rtlamr"
+RTLAMR = "/usr/bin/rtlamr"
 
 # path to rtl_tcp
 RTL_TCP = "/usr/bin/rtl_tcp"

--- a/amridm2mqtt/rootfs/etc/services.d/amridm2mqtt/run
+++ b/amridm2mqtt/rootfs/etc/services.d/amridm2mqtt/run
@@ -64,8 +64,8 @@ case "$(bashio::config 'log_level')" in \
     fatal)      log_level='CRITICAL' ;; \
     *)          log_level='INFO' ;; \
 esac;
-export CMD_LOGLEVEL="${log_level}"
-bashio::log.info "Hedgedoc log level set to ${log_level}"
+export LOG_LEVEL="${log_level}"
+bashio::log.info "Log level set to ${log_level}"
 
 
 bashio::log.info 'Handing over control to AMRIDM2MQTT...'


### PR DESCRIPTION
- `LOG_LEVEL` not `CMD_LOGLEVEL` (copy paste error from hedgedoc)
- Empty string check when getting watched meters in `settings.py`
- Correct path for rtlamr binary
- Example config needs an empty `mqtt` node to pass validation
