### PR TITLE
Map udev and add rtl-sdr config/rules

### DIFF
--- a/amridm2mqtt/config.yaml
+++ b/amridm2mqtt/config.yaml
@@ -10,6 +10,7 @@ arch:
   - armhf
 description: AMRIDM2MQTT for Home Assistant
 uart: true
+udev: true
 services:
   - mqtt:want
 map:

--- a/amridm2mqtt/rootfs/etc/modprobe.d/rtl-sdr.conf
+++ b/amridm2mqtt/rootfs/etc/modprobe.d/rtl-sdr.conf
@@ -1,0 +1,1 @@
+blacklist dvb_usb_rtl28xxu

--- a/amridm2mqtt/rootfs/etc/udev/rules.d/rtl-sdr.rules
+++ b/amridm2mqtt/rootfs/etc/udev/rules.d/rtl-sdr.rules
@@ -1,0 +1,1 @@
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE:="0666"


### PR DESCRIPTION
- Add `udev: true` in config to access that
- Add permission rule for device
- Denylist tv tuner devices that might be broadcasting