### PR TITLE
Fix message types config option

### DIFF
--- a/amridm2mqtt/config.yaml
+++ b/amridm2mqtt/config.yaml
@@ -29,7 +29,7 @@ schema:
   wh_multiplier: int(1,)
   readings_per_hour: int(1,)
   message_types:
-    - list(scm,idm)
+    - list(scm|idm)
   mqtt:
     host: str?
     ca: str?


### PR DESCRIPTION
Enum was done incorrectly, options need to be pipe-separated not comma-separated